### PR TITLE
art_brain: allow z axis increment

### DIFF
--- a/art_brain/src/node.py
+++ b/art_brain/src/node.py
@@ -497,10 +497,10 @@ class ArtBrain:
         goal = pickplaceGoal()
         goal.operation = goal.PLACE
         goal.id = obj
-        
+
         # TODO how to decide between 180 and 90 deg?
-        goal.z_axis_angle_increment = 3.14/2 # allow object to be rotated by 90 deg around z axis
-        
+        goal.z_axis_angle_increment = 3.14/2  # allow object to be rotated by 90 deg around z axis
+
         goal.place_pose = PoseStamped()
 
         goal.place_pose = place

--- a/art_brain/src/node.py
+++ b/art_brain/src/node.py
@@ -497,6 +497,10 @@ class ArtBrain:
         goal = pickplaceGoal()
         goal.operation = goal.PLACE
         goal.id = obj
+        
+        # TODO how to decide between 180 and 90 deg?
+        goal.z_axis_angle_increment = 3.14/2 # allow object to be rotated by 90 deg around z axis
+        
         goal.place_pose = PoseStamped()
 
         goal.place_pose = place


### PR DESCRIPTION
@Kapim Tohle by mělo zlepšit úspěšnost při pokládání objektů. Není vyžadovaná přesná orientace - objekt může být otočený v násobcích 90° kolem osy z. Tohle je ale ok jenom pro profily "nastojato". Pro delší profily, které budou na stole ležet "naplocho" bude ok jen 180°.